### PR TITLE
Use binder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM andrewosh/binder-base
-
-MAINTAINER Matthew Feickert <matthew.feickert@cern.ch>
-
-USER root

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Personal notes on statistics with a focus on applications to experimental high e
 
 Most of the notes are in the form of [Jupyter](http://jupyter.org/) notebooks, which are organized in the `Notebooks` directory.
 
-[![license](https://img.shields.io/github/license/matthewfeickert/Statistics-Notes.svg)]() [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org:/repo/matthewfeickert/statistics-notes) [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/matthewfeickert/Statistics-Notes/tree/master/Notebooks/)
+[![license](https://img.shields.io/github/license/matthewfeickert/Statistics-Notes.svg)]() [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/matthewfeickert/Statistics-Notes/master) [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/matthewfeickert/Statistics-Notes/tree/master/Notebooks/)
 
 ## References
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ipywidgets
+matplotlib
+numpy
+scipy
+sympy


### PR DESCRIPTION
To use the new (as of 2017) version 2 of Binder less information is needed. Instead of a complete Dockerfile environmental requirements can be used instead. As this repo is primarily Python Jupyter notebooks then the Dockerfile can be replaced with a pip `requirements.txt`.