### PR TITLE
Use updated papermill v0.16 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ cache: pip
 python: '3.6'
 install:
 - pip install --upgrade pip
-- pip install -U -q -r binder/requirements.txt
+- pip install --upgrade -q -r binder/requirements.txt
+- pip freeze
 script:
   - pytest
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,5 +3,5 @@ matplotlib
 numpy
 scipy
 sympy
-papermill
+papermill~=0.16
 pytest

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -5,7 +5,7 @@ import papermill as pm
 def test_notebooks_all_execute(tmpdir):
     outputnb = tmpdir.join('output.ipynb')
     common_kwargs = {
-        'output': str(outputnb),
+        'output_path': str(outputnb),
         'kernel_name': 'python{}'.format(sys.version_info.major)
     }
 


### PR DESCRIPTION
# Description

Use the updated papermill `v0.16` API that uses `output_path` instead of `output`. Also require papermill to be compatible with `v0.16` by using PEP 440/508's compatible version syntax. This ensures that the API should be stable as it will remain at `v0.Y` versions even after major release `v1.Y.Z` is released.

This also has the nice feature of being able to intentionally choose when to update to a newer backend API even if the backend has had a new major release with API breaking changes for a long time.

Noting that if the release is specified down to the bug fix release (`X.Y.Z`) then it will be pinned down to the minor release (`X.Y`). c.f. [PEP 404](https://www.python.org/dev/peps/pep-0440/#compatible-release):

>  the following groups of version clauses are equivalent:
> ```
> ~= 1.4.5
> >= 1.4.5, == 1.4.*
> ```

so as updates from other libraries are desirable, as long as there is no API breaking changes, then all dependencies should be specified as

```
~= X.Y
```

unless they need to be specified all the way down to `X.Y.*`

c.f.
 - https://www.python.org/dev/peps/pep-0440/#compatible-release
 - https://www.python.org/dev/peps/pep-0508

```
- Use updated papermill `v0.16` API
- Require papermill version compatible with v0.16 by using PEP 440/508's compatible version syntax
- Add pip freeze to Travis to make viewing the environment easier
```