### PR TITLE
Use papermill releases compatible with v1.0

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,5 +3,5 @@ matplotlib
 numpy
 scipy
 sympy
-papermill~=0.16
+papermill~=1.0
 pytest


### PR DESCRIPTION
With the release of [`papermill` `v1.0`](https://github.com/nteract/papermill/releases/tag/1.0.0) the API is stabilized and should be used.