### PR TITLE
Add Binder build to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+dist: xenial
 language: python
 cache: pip
-python: '3.6'
+python: '3.7'
 install:
 - pip install --upgrade pip
 - pip install --upgrade -q -r binder/requirements.txt
@@ -10,3 +11,15 @@ script:
 
 stages:
   - test
+  - name: binder
+    if: (branch = master) AND (NOT (type IN (pull_request)))
+
+jobs:
+  include:
+  - stage: test
+  - stage: binder
+    before_install: skip
+    install: skip
+    script:
+      # Use Binder build API to trigger repo2docker to build image
+      - bash binder/trigger_binder.sh https://mybinder.org/build/gh/matthewfeickert/Statistics-Notes/"${TRAVIS_BRANCH}"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Most of the notes are in the form of [Jupyter](http://jupyter.org/) notebooks, w
 [![license](https://img.shields.io/github/license/matthewfeickert/Statistics-Notes.svg)]()
 [![DOI](https://zenodo.org/badge/91207877.svg)](https://zenodo.org/badge/latestdoi/91207877)
 [![Build Status](https://travis-ci.com/matthewfeickert/Statistics-Notes.svg?branch=master)](https://travis-ci.com/matthewfeickert/Statistics-Notes)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/matthewfeickert/Statistics-Notes/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/Statistics-Notes/master)
 [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/matthewfeickert/Statistics-Notes/tree/master/Notebooks/)
 
 ## References

--- a/binder/trigger_binder.sh
+++ b/binder/trigger_binder.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function trigger_binder() {
+    local URL="${1}"
+
+    curl --connect-timeout 10 --max-time 30 "${URL}"
+    curl_return=$?
+
+    # Return code 28 is when the --max-time is reached
+    if [ "${curl_return}" -eq 0 ] || [ "${curl_return}" -eq 28 ]; then
+        if [[ "${curl_return}" -eq 28 ]]; then
+            printf "\nBinder build started.\nCheck back soon.\n"
+        fi
+    else
+        return "${curl_return}"
+    fi
+
+    return 0
+}
+
+function main() {
+    # 1: the Binder build API URL to curl
+    trigger_binder $1
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
* Use the Binder build API endpoint with curl to trigger builds
   - https://gitter.im/jupyterhub/binder?at=5c2f87038dafa715c73ff54f
   - https://github.com/jupyterhub/binderhub/blob/9ca8fa68bb8b69c6a2736f2275279583073f314f/examples/binder-api.py#L28
* Have Binder build API call in separate Binder stage that runs only on PR merges to master
* Add Bash script to guard max time return value for Binder build
* Update the Binder logo to the modern version