### PR TITLE
Add GitHub actions workflow

### DIFF
--- a/.github/actions/tests/entrypoint.sh
+++ b/.github/actions/tests/entrypoint.sh
@@ -7,7 +7,7 @@ function print_and_run () {
 
 print_and_run "which python"
 print_and_run "which pip"
-print_and_run "pip install --upgrade -q pip setuptools wheel"
+print_and_run "pip install --upgrade --no-cache-dir -q  pip setuptools wheel"
 print_and_run "pip list"
 
 # Already there, but to make it clear to reader
@@ -15,7 +15,7 @@ print_and_run "cd ${GITHUB_WORKSPACE}"
 
 print_and_run "python --version"
 print_and_run "pip --version"
-print_and_run "pip install --upgrade -q -r binder/requirements.txt"
+print_and_run "pip install --upgrade --no-cache-dir -q -r binder/requirements.txt"
 print_and_run "pip list"
 
 print_and_run "pytest"

--- a/.github/actions/tests/entrypoint.sh
+++ b/.github/actions/tests/entrypoint.sh
@@ -2,7 +2,7 @@
 
 function print_and_run () {
     printf "\n# %s\n" "${1}"
-    eval $( echo "$1")
+    eval $(echo "$1")
 }
 
 print_and_run "which python"

--- a/.github/actions/tests/entrypoint.sh
+++ b/.github/actions/tests/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+function print_and_run () {
+    printf "\n# %s\n" "${1}"
+    eval $( echo "$1")
+}
+
+print_and_run "which python"
+print_and_run "which pip"
+print_and_run "pip install --upgrade -q pip setuptools wheel"
+print_and_run "pip list"
+
+# Already there, but to make it clear to reader
+print_and_run "cd ${GITHUB_WORKSPACE}"
+
+print_and_run "python --version"
+print_and_run "pip --version"
+print_and_run "pip install --upgrade -q -r binder/requirements.txt"
+print_and_run "pip list"
+
+print_and_run "pytest"

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,14 @@
+workflow "Test Python 3" {
+  on = "push"
+  resolves = ["Python 3.6.8 Debian", "Python 3.7.3 Debian"]
+}
+
+action "Python 3.6.8 Debian" {
+  uses = "docker://python:3.6.8"
+  runs = "./.github/actions/tests/entrypoint.sh"
+}
+
+action "Python 3.7.3 Debian" {
+  uses = "docker://python:3.7.3"
+  runs = "./.github/actions/tests/entrypoint.sh"
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,11 +1,17 @@
-workflow "Test Python 3" {
+workflow "Test Python 3.6.8" {
   on = "push"
-  resolves = ["Python 3.6.8 Debian", "Python 3.7.3 Debian"]
+  resolves = ["Python 3.6.8 Debian"]
 }
 
 action "Python 3.6.8 Debian" {
   uses = "docker://python:3.6.8"
   runs = "./.github/actions/tests/entrypoint.sh"
+}
+
+
+workflow "Test Python 3.7.3" {
+  on = "push"
+  resolves = ["Python 3.7.3 Debian"]
 }
 
 action "Python 3.7.3 Debian" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,7 +8,6 @@ action "Python 3.6.8 Debian" {
   runs = "./.github/actions/tests/entrypoint.sh"
 }
 
-
 workflow "Test Python 3.7.3" {
   on = "push"
   resolves = ["Python 3.7.3 Debian"]
@@ -17,4 +16,9 @@ workflow "Test Python 3.7.3" {
 action "Python 3.7.3 Debian" {
   uses = "docker://python:3.7.3"
   runs = "./.github/actions/tests/entrypoint.sh"
+}
+
+workflow "Monthly Test Python 3.7.3" {
+  on = "schedule(0 0 1 * *)"
+  resolves = ["Python 3.7.3 Debian"]
 }


### PR DESCRIPTION
# Description

Add GitHub Actions workflows that tests the Jupyter notebooks in Python 3.6.8 and Python 3.7.3 Debian [Docker images](https://hub.docker.com/_/python) by running an install and test suite defined in `entrypoint.sh`. The tests are split between two workflows so that a failure on one does not automatically fail and stop the other.