### PR TITLE
chore: Update to Jupyter Book v0.12.1

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,4 @@
 ipywidgets
-matplotlib
-numpy
-scipy
-sympy
+matplotlib==3.5.0
+scipy==1.7.3
+sympy==1.9

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -1,7 +1,8 @@
 # https://jupyterbook.org/customize/toc.html
-- file: introduction
-
-- part: Introduction
+format: jb-book
+root: introduction
+parts:
+- caption: Introduction
   chapters:
   - file: notebooks/Introductory/Likelihood-Function
     title: The Likelihood Function
@@ -10,24 +11,24 @@
   - file: notebooks/Introductory/Gaussian-Sampling.ipynb
     title: Gaussian Sampling
 
-- part: Probability Distributions
+- caption: Probability Distributions
   chapters:
   - file: notebooks/Introductory/Gaussian-Distribution.ipynb
     title: The Normal Distribution
   - file: notebooks/Introductory/Chi-Squared-Distribution.ipynb
     title: Chi-Squared Distribution
 
-- part: Results of Probability Theory
+- caption: Results of Probability Theory
   chapters:
   - file: notebooks/Introductory/probability-integral-transform.ipynb
     title: Probability Integral Transform
 
-- part: Simulation
+- caption: Simulation
   chapters:
   - file: notebooks/simulation/Rejection-Sampling-MC.ipynb
     title: Monte Carlo Simulation via Rejection Sampling
 
-- part: Concepts in HEP
+- caption: Concepts in HEP
   chapters:
   - file: notebooks/HEP/Extended-Likelihood.ipynb
     title: Extended Likelihood

--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-book~=0.8.0
+jupyter-book==0.8.3

--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-book==0.8.3
+jupyter-book==0.12.1


### PR DESCRIPTION
```
* Update to Jupyter Book v0.12.1
* Migrate _toc.yml to use Jupyter Book v0.11+ syntax
   - c.f. https://executablebooks.org/en/latest/updates/2021-06-18-update-toc.html
* Pin to jupyter-book==0.12.1
* Pin requirements dependencies to latest releases
```